### PR TITLE
[bje-load-exceptions] keep loading after bad objects

### DIFF
--- a/src/main/java/net/apnic/whowas/history/History.java
+++ b/src/main/java/net/apnic/whowas/history/History.java
@@ -158,7 +158,7 @@ public final class History implements Externalizable {
     private AvlTree<IP, ObjectKey, IpInterval> updateIntervalTree(ObjectKey objectKey, AvlTree<IP, ObjectKey, IpInterval> nextTree) {
         try {
             IpInterval interval = Parsing.parseInterval(objectKey.getObjectName());
-            nextTree = tree.update(interval, objectKey, (a,b) -> {
+            nextTree = nextTree.update(interval, objectKey, (a,b) -> {
                 assert a.equals(b);
                 return a;
             }, o -> o);


### PR DESCRIPTION
Fix a bug where loading will stop having any effect after the first error encountered.