### PR TITLE
Defer initialising tomcat until initial data load is complete

### DIFF
--- a/src/main/java/net/apnic/whowas/App.java
+++ b/src/main/java/net/apnic/whowas/App.java
@@ -25,7 +25,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
@@ -42,7 +41,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.Properties;
 import java.util.stream.Stream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
@@ -103,14 +101,12 @@ public class App {
     ApplicationContext context;
 
     @Autowired
-    private JdbcOperations jdbcOperations;
-
     private RipeDbLoader dbLoader;
+
     private Exception lastDbException = null;
 
     @PostConstruct
     public void initialise() {
-        dbLoader = new RipeDbLoader(jdbcOperations, -1L);
         executorService.execute(this::buildTree);
     }
 

--- a/src/main/java/net/apnic/whowas/App.java
+++ b/src/main/java/net/apnic/whowas/App.java
@@ -57,16 +57,7 @@ public class App {
     private final History history = new History();
 
     public static void main(String[] args) {
-        SpringApplication app = new SpringApplication(App.class);
-        Properties defaultProps = new Properties();
-
-        defaultProps.setProperty(
-                "spring.mvc.throw-exception-if-no-handler-found", "true");
-        defaultProps.setProperty("spring.resources.add-mappings", "false");
-        defaultProps.setProperty("spring.mvc.favicon.enabled", "false");
-        defaultProps.setProperty("management.add-application-context-header", "false");
-        app.setDefaultProperties(defaultProps);
-        app.run(args);
+        SpringApplication.run(App.class, args);
     }
 
     @Bean

--- a/src/main/java/net/apnic/whowas/loaders/RipeDbLoader.java
+++ b/src/main/java/net/apnic/whowas/loaders/RipeDbLoader.java
@@ -7,9 +7,13 @@ import net.apnic.whowas.rdap.GenericObject;
 import net.apnic.whowas.types.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,14 +25,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Component
 public class RipeDbLoader implements Loader {
     private static final Logger LOGGER = LoggerFactory.getLogger(RipeDbLoader.class);
 
     private long lastSerial;
     private final transient JdbcOperations operations;
 
-    public RipeDbLoader(JdbcOperations jdbcOperations, long serial) {
-        this.lastSerial = serial;
+    public RipeDbLoader(JdbcOperations jdbcOperations) {
+        this.lastSerial = -1;
         this.operations = jdbcOperations;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,8 +27,17 @@ spring:
     username: "${database.username}"
     password: "${database.password}"
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+    favicon:
+      enabled: false
+  resources:
+    add-mappings: false
+
+
 management:
   port: 8081
+  add-application-context-header: false
 
 info:
   build:

--- a/src/test/java/net/apnic/whowas/InitialisationTest.java
+++ b/src/test/java/net/apnic/whowas/InitialisationTest.java
@@ -1,0 +1,58 @@
+package net.apnic.whowas;
+
+import net.apnic.whowas.loaders.RipeDbLoader;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class InitialisationTest {
+
+    @Test
+    public void initialDataIsLoadedBeforeServletIsStarted() {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+
+        System.setProperty("server.port", "0");
+        System.setProperty("management.port", "-1");
+
+        SpringApplication springApplication = new SpringApplication(App.class);
+        springApplication.addInitializers(configurableApplicationContext ->
+                configurableApplicationContext.addBeanFactoryPostProcessor(beanFactory ->
+                        beanFactory.registerResolvableDependency(
+                                RipeDbLoader.class, new RipeDbLoader(new JdbcTemplate()) {
+                                    @Override
+                                    public void loadWith(RevisionConsumer consumer) {
+                                        sleep(1000);
+                                        events.add("Data loaded");
+                                    }
+                                }
+                        )
+                )
+        );
+        springApplication.addListeners(
+                (ApplicationListener<EmbeddedServletContainerInitializedEvent>) applicationEvent ->
+                        events.add("Servlet container started")
+        );
+
+        try(ConfigurableApplicationContext context = springApplication.run()) {
+            assertThat("Data was loaded before tomcat was initialised",
+                    new ArrayList<>(events).get(0), is("Data loaded"));
+        }
+    }
+
+    private static void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This is probably a nice property to have in order to avoid returning responses based on partially loaded data whilst the data is still being loaded.

Also this change results in @Transactional now being applied, though I haven't thought of a reasonable way to test this. The transaction belongs to RipeDbLoader, but whether it's applied is a function of how it is called (i.e. whether the call can be intercepted by a dynamic proxy). So it can really only be integration tested in the context where its called. Alternatives would be to refactor to a TransactionTemplate which isn't dependent on dynamic proxies, or to just not test.  