### PR TITLE
Defer tomcat startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,9 +336,9 @@
                                 </entryPoint>
                                 <workdir>/app</workdir>
                                 <healthCheck>
-                                    <interval>1m</interval>
+                                    <interval>10s</interval>
                                     <timeout>15s</timeout>
-                                    <retries>7</retries>
+                                    <retries>3</retries>
                                     <cmd>curl -f http://localhost:8081/health || exit 1</cmd>
                                 </healthCheck>
                                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -336,9 +336,9 @@
                                 </entryPoint>
                                 <workdir>/app</workdir>
                                 <healthCheck>
-                                    <interval>10s</interval>
+                                    <interval>1m</interval>
                                     <timeout>15s</timeout>
-                                    <retries>3</retries>
+                                    <retries>7</retries>
                                     <cmd>curl -f http://localhost:8081/health || exit 1</cmd>
                                 </healthCheck>
                                 <assembly>

--- a/src/main/java/net/apnic/whowas/App.java
+++ b/src/main/java/net/apnic/whowas/App.java
@@ -1,24 +1,11 @@
 package net.apnic.whowas;
 
-import java.util.Properties;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class App {
-
-    public static void main(String[] args)
-    {
-        SpringApplication app = new SpringApplication(App.class);
-        Properties defaultProps = new Properties();
-
-        defaultProps.setProperty(
-                "spring.mvc.throw-exception-if-no-handler-found", "true");
-        defaultProps.setProperty("spring.resources.add-mappings", "false");
-        defaultProps.setProperty("spring.mvc.favicon.enabled", "false");
-        defaultProps.setProperty("management.add-application-context-header", "false");
-        app.setDefaultProperties(defaultProps);
-        app.run(args);
+    public static void main(String[] args) {
+        SpringApplication.run(App.class, args);
     }
 }

--- a/src/main/java/net/apnic/whowas/loaders/RipeDbLoader.java
+++ b/src/main/java/net/apnic/whowas/loaders/RipeDbLoader.java
@@ -20,17 +20,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+@Component
 public class RipeDbLoader implements Loader {
     private static final Logger LOGGER = LoggerFactory.getLogger(RipeDbLoader.class);
 
     private long lastSerial;
     private final transient JdbcOperations operations;
 
-    public RipeDbLoader(JdbcOperations jdbcOperations, long serial) {
-        this.lastSerial = serial;
+    public RipeDbLoader(JdbcOperations jdbcOperations) {
+        this.lastSerial = -1;
         this.operations = jdbcOperations;
     }
 

--- a/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
+++ b/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
@@ -48,6 +48,8 @@ public class LoaderConfiguration
 
     @Autowired
     private ApplicationContext context;
+
+    @Autowired
     private RipeDbLoader dbLoader;
 
     @Value("${snapshot.file:#{null}}")
@@ -55,9 +57,6 @@ public class LoaderConfiguration
 
     @Autowired
     History history;
-
-    @Autowired
-    private JdbcOperations jdbcOperations;
 
     @Autowired
     SearchEngine searchEngine;
@@ -105,9 +104,7 @@ public class LoaderConfiguration
     }
 
     @PostConstruct
-    public void initialise()
-    {
-        dbLoader = new RipeDbLoader(jdbcOperations, -1L);
+    public void initialise() {
         executorService.execute(this::buildTree);
     }
 

--- a/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
+++ b/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
@@ -7,10 +7,7 @@ import java.io.IOException;
 import java.time.temporal.ChronoUnit;
 import java.time.ZonedDateTime;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 import javax.annotation.PostConstruct;
@@ -104,8 +101,14 @@ public class LoaderConfiguration
     }
 
     @PostConstruct
-    public void initialise() {
-        executorService.execute(this::buildTree);
+    public void initialise() throws ExecutionException, InterruptedException {
+            /*
+          Scoping the initial load of data to @PostConstruct
+          results in the loading completing before the servlet context is started,
+                    preventing requests from being served from partially loaded data.
+        */
+        Future initialDataLoaded = executorService.submit(this::buildTree);
+        initialDataLoaded.get();
     }
 
     @Scheduled(fixedRate = 15000L)

--- a/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
+++ b/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @EnableScheduling
@@ -56,6 +57,13 @@ public class LoaderConfiguration
 
     @Autowired
     SearchEngine searchEngine;
+
+    /*
+        This is autowired here to trigger Spring to initialise the transaction manager bean
+        before @PostConstruct is invoked. Without this, the initial data load will hang.
+     */
+    @Autowired
+    PlatformTransactionManager platformTransactionManager;
 
     private void buildTree()
     {

--- a/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
+++ b/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
@@ -30,8 +30,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
@@ -116,6 +118,11 @@ public class LoaderConfiguration
         */
         Future initialDataLoaded = executorService.submit(this::buildTree);
         initialDataLoaded.get();
+    }
+
+    @Bean
+    TaskScheduler taskScheduler() {
+        return new ThreadPoolTaskScheduler();
     }
 
     @Scheduled(fixedRate = 15000L)

--- a/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
+++ b/src/main/java/net/apnic/whowas/loaders/config/LoaderConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.ApplicationContext;
-import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,8 +30,17 @@ spring:
     username: "${database.username}"
     password: "${database.password}"
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+    favicon:
+      enabled: false
+  resources:
+    add-mappings: false
+
+
 management:
   port: 8081
+  add-application-context-header: false
 
 info:
   build:

--- a/src/test/java/net/apnic/whowas/InitialisationTest.java
+++ b/src/test/java/net/apnic/whowas/InitialisationTest.java
@@ -1,0 +1,58 @@
+package net.apnic.whowas;
+
+import net.apnic.whowas.loaders.RipeDbLoader;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class InitialisationTest {
+
+    @Test
+    public void initialDataIsLoadedBeforeServletIsStarted() {
+        ConcurrentLinkedQueue<String> events = new ConcurrentLinkedQueue<>();
+
+        System.setProperty("server.port", "0");
+        System.setProperty("management.port", "-1");
+
+        SpringApplication springApplication = new SpringApplication(App.class);
+        springApplication.addInitializers(configurableApplicationContext ->
+                configurableApplicationContext.addBeanFactoryPostProcessor(beanFactory ->
+                        beanFactory.registerResolvableDependency(
+                                RipeDbLoader.class, new RipeDbLoader(new JdbcTemplate()) {
+                                    @Override
+                                    public void loadWith(RevisionConsumer consumer) {
+                                        sleep(1000);
+                                        events.add("Data loaded");
+                                    }
+                                }
+                        )
+                )
+        );
+        springApplication.addListeners(
+                (ApplicationListener<EmbeddedServletContainerInitializedEvent>) applicationEvent ->
+                        events.add("Servlet container started")
+        );
+
+        try(ConfigurableApplicationContext context = springApplication.run()) {
+            assertThat("Data was loaded before tomcat was initialised",
+                    new ArrayList<>(events).get(0), is("Data loaded"));
+        }
+    }
+
+    private static void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This is probably a nice property to have in order to avoid returning responses based on partially loaded data whilst the data is still being loaded.

Also this change results in @transactional now being applied, though I haven't thought of a reasonable way to test this. The transaction belongs to RipeDbLoader, but whether it's applied is a function of how it is called (i.e. whether the call can be intercepted by a dynamic proxy). So it can really only be integration tested in the context where its called. Alternatives would be to refactor to a TransactionTemplate which isn't dependent on dynamic proxies, or to just not test.

* re-created PR off of updated develop branch