### PR TITLE
Fixes bug that expects \n at the end of RPSL

### DIFF
--- a/src/main/java/net/apnic/whowas/rpsl/RpslParser.java
+++ b/src/main/java/net/apnic/whowas/rpsl/RpslParser.java
@@ -23,7 +23,7 @@ class RpslParser {
             .toScanner("RPSL attribute name").source().map(String::toLowerCase);
 
     private static final Parser<String> LINE = Scanners.many(CharPredicates.notChar('\n')).source()
-            .followedBy(Scanners.isChar('\n'));
+            .followedBy(Parsers.or(Scanners.isChar('\n'), Parsers.EOF));
 
     private static final Parser<Void> CONTINUATION_MARKER = Parsers.or(
             Scanners.among(" \t").followedBy(WHITESPACE),

--- a/src/test/java/net/apnic/whowas/rpsl/RpslParserTest.java
+++ b/src/test/java/net/apnic/whowas/rpsl/RpslParserTest.java
@@ -45,9 +45,12 @@ public class RpslParserTest {
                 is(expected));
     }
 
-    @Test(expected = ParserException.class)
-    public void newlineRequired() {
+    // Regression test for when the whowas required that all RPSL end with \n
+    // We now require that EOF be found or \n
+    public void newlineOrEofRequired() {
         RpslParser.parseObject("role: Tester\nhandle:TST1-AP");
+        RpslParser.parseObject("handle:TST1-AP");
+        RpslParser.parseObject("handle:TST1-AP\n");
     }
 
     @Test


### PR DESCRIPTION
Simple fix that now makes the end of an RPSL attribute be either EOF of \n