### PR TITLE
Build changes to rdapd docker image.

### DIFF
--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -2,9 +2,6 @@
 
 echo "Launching with arguments: $@"
 
-JVM_INIT_MEM="${JVM_INIT_MEM:-4G}"
-JVM_MAX_MEM="${JVM_MAX_MEM:-8G}"
-
-exec java -Xms${JVM_INIT_MEM} -Xmx${JVM_MAX_MEM} \
-	-jar /app/@project.artifactId@-@project.version@.@project.packaging@ \
-	--spring.config.location=/app/config/application.yml
+exec java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap \
+    -jar /app/rdapd.jar \
+    --spring.config.location=/app/config/application.yml


### PR DESCRIPTION
* Now builds using docker multi stage support. This allows for using native open
  jdk containers.
* Uses new jvm options to detect docker memory limits. Should no longer need to
  tune this through env vars.